### PR TITLE
clean up package.json both for package and app, update dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -4,15 +4,12 @@
   "version": "3.0.0",
   "description": "The perfect Twitch companion for your Mac or Windows PC or Linux PC. PogChamp",
   "author": "Bryan Veloso <bryan@avalonstar.com>",
-  "main": "",
+  "main": "index.js",
   "dependencies": {
     "body-parser": "1.15.0",
     "cookie-parser": "1.4.1",
     "cookie-session": "2.0.0-alpha.1",
     "electron-debug": "^0.5.2",
     "express": "4.13.4"
-  },
-  "devDependencies": {
-    "electron-prebuilt": "^0.36.9"
   }
 }

--- a/app/start.js
+++ b/app/start.js
@@ -1,3 +1,0 @@
-const electron = require('electron-prebuilt');
-const proc = require('child_process');
-const child = proc.spawn(electron, ['.']);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "start": "node ./app/start.js",
+    "start": "electron ./app",
     "build": "electron-packager . Shiver --prune --asar --platform=darwin --arch=x64 --version=0.27.2"
   },
   "keywords": [
@@ -23,7 +23,7 @@
     "twitch"
   ],
   "devDependencies": {
-    "electron-packager": "^4.1.2",
-    "electron-prebuilt": "^0.27.2"
+    "electron-packager": "^7.0.1",
+    "electron-prebuilt": "^0.37.7"
   }
 }


### PR DESCRIPTION
clean up package.json both for package and app

don't need to call the start.js to spawn electron since we can just use the package root node_modules to execute it as part of npm start
set npm start to run electron ./app
update dependencies to solve the npm start issue

the old electron-prebuilt was causing the issue with not looking at the parent folder's node_modules causing the can't find electron error on app run
the old electron-packager has a security issue with not checking ssl validity, so forcing 7.0.0+ is a must
remove start.js as it's no longer needed

duplicate of #1 due to an unwanted commit squash
